### PR TITLE
Remove defaultMaxSize limit from file comparisons

### DIFF
--- a/equalfile.go
+++ b/equalfile.go
@@ -160,7 +160,11 @@ func (c *Cmp) CompareFile(path1, path2 string) (bool, error) {
 	// defaultMaxSize.  Growing files will return an error during the
 	// comparison.
 	if c.Opt.MaxSize == 0 {
-		c.Opt.MaxSize = info1.Size()
+		if info1.Size() > 0 {
+			c.Opt.MaxSize = info1.Size()
+		} else {
+			c.Opt.MaxSize = 1
+		}
 	}
 
 	return c.CompareReader(r1, r2)

--- a/equalfile.go
+++ b/equalfile.go
@@ -9,7 +9,7 @@ import (
 	"os"
 )
 
-const defaultMaxSize = 10000000000 // Only the first 10^10 bytes are compared.
+const defaultMaxSize = 10000000000 // Only the first 10^10 bytes of io.Reader are compared.
 const defaultBufSize = 20000
 
 type Options struct {
@@ -154,6 +154,13 @@ func (c *Cmp) CompareFile(path1, path2 string) (bool, error) {
 		if os.SameFile(info1, info2) {
 			return true, nil
 		}
+	}
+
+	// For files, set MaxSize to the initial Stat() size, rather than the
+	// defaultMaxSize.  Growing files will return an error during the
+	// comparison.
+	if c.Opt.MaxSize == 0 {
+		c.Opt.MaxSize = info1.Size()
 	}
 
 	return c.CompareReader(r1, r2)

--- a/equalfile.go
+++ b/equalfile.go
@@ -47,9 +47,6 @@ func NewMultiple(buf []byte, options Options, h hash.Hash, compareOnMatch bool) 
 		hashTable:        map[string]hashSum{},
 		buf:              buf,
 	}
-	if c.Opt.MaxSize == 0 {
-		c.Opt.MaxSize = defaultMaxSize
-	}
 	if c.buf == nil || len(c.buf) == 0 {
 		c.buf = make([]byte, defaultBufSize)
 	}
@@ -219,6 +216,10 @@ func readPartial(c *Cmp, r io.Reader, buf []byte, n1, n2 int) (int, error) {
 }
 
 func (c *Cmp) compareReader(r1, r2 io.Reader) (bool, error) {
+
+	if c.Opt.MaxSize == 0 {
+		c.Opt.MaxSize = defaultMaxSize
+	}
 
 	maxSize := c.Opt.MaxSize
 	if maxSize < 1 {

--- a/equalfile_nowin_test.go
+++ b/equalfile_nowin_test.go
@@ -10,7 +10,7 @@ import (
 func TestCompareLimitBroken(t *testing.T) {
 	buf := make([]byte, 1000)
 	compare(t, New(nil, Options{ForceFileRead: true, MaxSize: -1}), "/etc/passwd", "/etc/passwd", expectError)
-	compare(t, New(buf, Options{ForceFileRead: true, MaxSize: 0}), "/etc/passwd", "/etc/passwd", expectEqual) // will switch to 10G default limit
+	compare(t, New(buf, Options{ForceFileRead: true, MaxSize: 0}), "/etc/passwd", "/etc/passwd", expectEqual) // will switch to filesize limit
 	compare(t, New(buf, Options{ForceFileRead: true, MaxSize: 1}), "/etc/passwd", "/etc/passwd", expectError) // will reach 1-byte limit
 	compare(t, New(buf, Options{ForceFileRead: true, MaxSize: 1000000}), "/etc/passwd", "/etc/passwd", expectEqual)
 }


### PR DESCRIPTION
For files, set the limit to the file size (after the file sizes are known to be the same).

It seems unintuitive to me that there should be a default MaxSize comparison limit for files.  For io.Readers with potentially unbound input and unknown size apriori, I can see a justification (although Go provides LimitReader already), but if someone compares two files, I think they'd naturally expect every byte to be considered by default.

This sets the limit to the Stat() size for CompareFiles(), which means that any non-growing file size is accommodated by default.  If files are growing in size, an error will be returned when the original Stat() MaxSize limit is reached (this seems sensible, comparing two files that are both growing is at best racy, and should be discouraged in any case).  The limit could be made MaxInt64 instead; it's a judgement call.