### PR TITLE
Restore CompareFiles() behavior on irregular files

### DIFF
--- a/equalfile.go
+++ b/equalfile.go
@@ -134,8 +134,10 @@ func (c *Cmp) CompareFile(path1, path2 string) (bool, error) {
 		}
 	}
 
-	if info1.Size() != info2.Size() {
-		return false, nil
+	if info1.Mode().IsRegular() && info2.Mode().IsRegular() {
+		if info1.Size() != info2.Size() {
+			return false, nil
+		}
 	}
 
 	// For files, set MaxSize to the initial Stat() size, rather than the
@@ -145,7 +147,7 @@ func (c *Cmp) CompareFile(path1, path2 string) (bool, error) {
 		if info1.Size() > 0 {
 			c.Opt.MaxSize = info1.Size()
 		} else {
-			c.Opt.MaxSize = 1
+			c.Opt.MaxSize = defaultMaxSize
 		}
 	}
 


### PR DESCRIPTION
Commit 1b0e261 changed CompareFiles() behavior for non-regular files (ie. character device files, etc) and this commit restores it.  Since non-regular files typically have Size() == 0 but can still return data
when Read(), often without ever reaching EOF, it reverts to using the defaultMaxSize for such files where the Size() value isn't accurate.

This PR is meant as a stop-gap to allow the option, now that the repo supports Go modules, to tag the merge commit with a Semantic Version tag (probably v0.2.0) for anyone who absolutely needs the previous behavior before upcoming commits possibly change things a bit.

Note - It seems unlikely anyone is or could be relying on this behavior anyway (comparing against character device inputs that don't return EOF), because exceeding MaxSize would inevitably cause CompareFiles() to return an error result.  So although this behavior is codified in the test cases, I don't think it's realistically depended upon.  Still, having a proper SemVer tagged version before upcoming commits is at least a starting point for conforming to the Go module versioning standard.