### PR TITLE
12 maxsize equality fix

### DIFF
--- a/equalfile.go
+++ b/equalfile.go
@@ -390,14 +390,15 @@ func (c *Cmp) compareReader(r1, r2 io.Reader, maxSize int64) (bool, error) {
 // LimitedReader after hitting EOF
 func postEOFCheck(c *Cmp, r io.Reader, buf []byte) (bool, error) {
 	tmpLR, isLR := r.(*io.LimitedReader)
-	if !isLR {
-		c.debugf("compareReader: A type assertion ot LimitedReader unexpectedly failed\n")
-		return true, fmt.Errorf("Couldn't cast Reader to LimitedReader: %v", r)
+	if isLR {
+		r = tmpLR.R
+	} else {
+		c.debugf("compareReader: A type assertion of LimitedReader unexpectedly failed\n")
 	}
 
 	// Attempt to read more bytes from the original readers, to determine
 	// if we should return an error for exceeding the MaxSize read limit.
-	n, _ := readPartial(c, tmpLR.R, buf, 0, len(buf))
+	n, _ := readPartial(c, r, buf, 0, len(buf))
 	if n > 0 {
 		c.debugf("compareReader: partial match, but max size exceeded\n")
 		return true, fmt.Errorf("max read size reached")


### PR DESCRIPTION
This addresses the issue (related to issue #12) of CompareReader() potentially using data read beyond the MaxSize amount in it's byte comparison value.  It ensures the data read by CompareReader() doesn't surpass the MaxSize amount, by using LimitedReader to force the Reader to return EOF after reading MaxSize bytes.  Then an additional check is done to see if more data exists to be read, thus returning an error that MaxSize has been exceeded.

This patch retains the current CompareReader() behavior of returning an error for exceeding MaxSize, even if the supplied Readers are LimitedReaders (with a MaxSize less than the limit).  I'll submit an additional PR that will modify this behavior so that if one or more LimitedReaders are provided to the CompareReader() func, thus indicating a user provided upper bound on the amount of bytes to be read, the MaxSize Option value is ignored.