### PR TITLE
12 limitedreader ignore maxsize

### DIFF
--- a/equalfile.go
+++ b/equalfile.go
@@ -407,6 +407,13 @@ func (c *Cmp) compareReader(r1, r2 io.Reader, maxSize int64) (bool, error) {
 func postEOFCheck(c *Cmp, r io.Reader, buf []byte) bool {
 	tmpLR, isLR := r.(*io.LimitedReader)
 	if isLR {
+		// If the limit wasn't reached, then we don't need to check for
+		// more data after the EOF
+		if tmpLR.N > 0 {
+			return true
+		}
+
+		// Use the internal Reader for checking for more data
 		r = tmpLR.R
 	} else {
 		c.debugf("compareReader: A type assertion of LimitedReader unexpectedly failed\n")

--- a/equalfile_test.go
+++ b/equalfile_test.go
@@ -212,11 +212,12 @@ func TestCompareReadersMaxSize(t *testing.T) {
 		{r1: LR(ER(2, 'a', 'b'), 2), r2: ER(2, 'z', 'b'), want: false, wantErr: false, maxSize: 2, desc: ", test 4g"},
 		{r1: LR(ER(2, 'a', 'b'), 2), r2: ER(2, 'z', 'b'), want: false, wantErr: false, maxSize: 2, bufSize: 2, desc: ", test 4h"},
 
-		// Try with MaxSize < LimitReader limits, which should trigger an error.
-		{r1: LR(ER(1, 'a', 'b'), 2), r2: LR(ER(1, 'a', 'c'), 2), want: true, wantErr: true, maxSize: 1, desc: ", test 5a"},
-		{r1: LR(ER(1, 'a', 'b'), 2), r2: LR(ER(1, 'a', 'c'), 2), want: true, wantErr: true, maxSize: 1, bufSize: 2, desc: ", test 5b"},
-		{r1: LR(ER(2, 'a', 'b'), 2), r2: LR(ER(2, 'a', 'c'), 2), want: true, wantErr: true, maxSize: 1, desc: ", test 5c"},
-		{r1: LR(ER(2, 'a', 'b'), 2), r2: LR(ER(2, 'a', 'c'), 2), want: true, wantErr: true, maxSize: 1, bufSize: 2, desc: ", test 5d"},
+		// Try with MaxSize < LimitReader limits, to show that MaxSize is ignored by
+		// CompareReader() when given one or more LimitReader
+		{r1: LR(ER(1, 'a', 'b'), 2), r2: LR(ER(1, 'a', 'c'), 2), want: false, wantErr: false, maxSize: 1, desc: ", test 5a"},
+		{r1: LR(ER(1, 'a', 'b'), 2), r2: LR(ER(1, 'a', 'c'), 2), want: false, wantErr: false, maxSize: 1, bufSize: 2, desc: ", test 5b"},
+		{r1: LR(ER(2, 'a', 'b'), 2), r2: LR(ER(2, 'a', 'c'), 2), want: true, wantErr: false, maxSize: 1, desc: ", test 5c"},
+		{r1: LR(ER(2, 'a', 'b'), 2), r2: LR(ER(2, 'a', 'c'), 2), want: true, wantErr: false, maxSize: 1, bufSize: 2, desc: ", test 5d"},
 
 		// Remove MaxSize from the equation.  Shouldn't return any errors.  Either
 		// unequal before EOF, or equal up to EOF.


### PR DESCRIPTION
This PR modifies behavior slightly, so I kept it separate from the previous PR #13, but it's essentially a follow on to it.  Now that we are detecting LimitedReader in CompareReader, this PR will use the user provided limit in the LimitedReader to prevent unbound reading from an infinite input, and so it ignores MaxSize entirely when one or more LimitedReader is passed to CompareReader().

The behavior change is if the MaxSize is set lower than the LimitedReader limit, the current behavior will return an error for exceeding MaxSize, whereas with this PR that is no longer true.  I don't expect it to be an issue in practice, as currently someone who deliberately wanted to use LimitedReader would have had to be careful to set MaxSize, and this change won't affect that (other than make it easier and hopefully more intuitive for future users).

Given the change, if the PR is accepted, I'd suggest bumping the release tag for the resulting merge commit to v0.3.0.